### PR TITLE
🐎 Do Not Export Identical Heritages Multiple Times

### DIFF
--- a/src/tasks/schema.ts
+++ b/src/tasks/schema.ts
@@ -40,6 +40,8 @@ function generateSchemasHelper(compilerOptions: any) {
 
   const exportedSymbols = getExportedSymbols(compilerOptions);
 
+  const heritage = JSON.stringify(getExportHeritage(compilerOptions), null, 2);
+
   const generatedSchemas = [];
 
   return through.obj(function (file, enc, cb) {
@@ -89,11 +91,7 @@ function generateSchemasHelper(compilerOptions: any) {
       indexContents += `module.exports.${schema} = require('./${schema}.json');\n`;
     });
 
-    const heritage = getExportHeritage(compilerOptions);
-
-    indexContents += `module.exports._heritage = `;
-    indexContents += JSON.stringify(heritage, null, 2);
-    indexContents += `;\n`;
+    indexContents += `module.exports._heritage = ${heritage};\n`;
 
     const indexFile = new File({
       path: 'index.js',


### PR DESCRIPTION
`getExportHeritage` was called for every file, but always with the same parameters. This is not necessary as far as i can tell, so i moved the call out of the loop. This saves about a third of the schema-creation time.

This reduced my process-engine-meta-setup by 10 minutes

building all schemas before:
<img width="1030" alt="bildschirmfoto 2018-01-27 um 17 19 15" src="https://user-images.githubusercontent.com/20770029/35474164-c538d046-038a-11e8-8788-3319e8e0edb5.png">

building all schemas now:
<img width="1031" alt="bildschirmfoto 2018-01-27 um 17 41 55" src="https://user-images.githubusercontent.com/20770029/35474166-cde92bfa-038a-11e8-9759-679c8464b681.png">
